### PR TITLE
setup.py: refactor deprecated distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@
 #
 """Python bindings for libstatgrab."""
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from subprocess import check_call, check_output, CalledProcessError
 
 import sys


### PR DESCRIPTION
The distutils module has been deprecated since 3.10 and will be removed in 3.12
https://peps.python.org/pep-0632/

distutils.core -> setuptools
https://setuptools.pypa.io/en/latest/userguide/ext_modules.html